### PR TITLE
Bump minimum R version to 4.3.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,15 +25,11 @@ jobs:
           - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
-          # use 4.1 to check with rtools40's older compiler
-          - {os: windows-latest, r: '4.1'}
 
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
+          # Require R >=4.3.0, for guaranteed C11 (particularly on Windows)
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: 'oldrel-2'}
-          - {os: ubuntu-latest,   r: 'oldrel-3'}
-          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: Provides bindings to tree-sitter, an incremental parsing
     presence of syntax errors.
 License: MIT + file LICENSE
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.3.0)
 Imports:
     cli (>= 3.6.2),
     R6 (>= 2.5.1),


### PR DESCRIPTION
tree-sitter requires C11 and is unlikely to change that https://github.com/tree-sitter/tree-sitter/pull/3339. C99 is old, so that's reasonable.

R's history with C99 is a big gnarly. R is currently at R 4.4.0 (released a month ago). Only as of R 4.3.0 (last year) did package authors gain a way to specify the C std version with `USE_Cxx` here:
https://github.com/wch/r-source/blob/bacd56452465bd7fd95839c3e5dd1adf21be4de6/doc/NEWS.Rd#L1572-L1604

Additionally at that time, there was a change in R on Windows to allow the default C compiler to be used (typically C17 through RTools), rather than always defaulting to C99. For Mac and Linux, it was already doing this (and indeed for me it looks like a pretty new C std is being used):
https://github.com/wch/r-source/blob/bacd56452465bd7fd95839c3e5dd1adf21be4de6/doc/NEWS.Rd#L1545-L1548

To try and guarantee Windows C11 support, we are raising the minimum R version to 4.3.0. 

I do not feel a need to specify a `USE_Cxx` field in `SystemRequirements`, as that specifies "use _up to_ this C standard" and we don't really want that - i.e. see the R NEWS linked above "Use a standard that is at most C17"