### PR TITLE
Show `MISSING` nodes in `node_show_s_expression()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Remotes:
-    treesitter.r=r-lib/tree-sitter-r/bindings/r@next
+    treesitter.r=r-lib/tree-sitter-r/bindings/r#112

--- a/R/print.R
+++ b/R/print.R
@@ -89,6 +89,7 @@ node_format_s_expression <- function(
 
 node_format_s_expression_recurse <- function(x, tokens, options) {
   is_named <- node_is_named(x)
+  is_missing <- node_is_missing(x)
 
   if (options$show_parentheses && is_named) {
     dyn_chr_push_back(tokens, color("(", options))
@@ -99,6 +100,9 @@ node_format_s_expression_recurse <- function(x, tokens, options) {
   type <- node_type(x)
   if (!is_named) {
     type <- encodeString(type, quote = "\"")
+  }
+  if (is_missing) {
+    type <- paste0(type, " MISSING")
   }
   dyn_chr_push_back(tokens, type)
 

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -439,3 +439,32 @@
       (program [(0, 0), (0, 1)]
         (float [(0, 0), (0, 1)]))
 
+# Named `MISSING` nodes are shown
+
+    Code
+      node_show_s_expression(node)
+    Output
+      (program [(0, 0), (2, 3)]
+        (binary_operator [(0, 0), (2, 0)]
+          lhs: (float [(0, 0), (0, 1)])
+          operator: "+" [(0, 2), (0, 3)]
+          rhs: (identifier MISSING [(2, 0), (2, 0)])
+        )
+      )
+
+# Anonymous `MISSING` nodes are shown
+
+    Code
+      node_show_s_expression(node)
+    Output
+      (program [(0, 0), (0, 13)]
+        (for_statement [(0, 0), (0, 13)]
+          "for" [(0, 0), (0, 3)]
+          "(" [(0, 4), (0, 5)]
+          variable: (identifier [(0, 5), (0, 6)])
+          "in" [(0, 7), (0, 9)]
+          sequence: (identifier [(0, 10), (0, 13)])
+          ")" MISSING [(0, 13), (0, 13)]
+        )
+      )
+

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -68,3 +68,31 @@ test_that("truncation doesn't show if you are exactly at `max_lines`", {
     node_show_s_expression(node, max_lines = 2, dangling_parenthesis = FALSE)
   })
 })
+
+test_that("Named `MISSING` nodes are shown", {
+  # Missing RHS - The newline seems to matter
+  text <- "1 +
+
+  ;"
+
+  parser <- parser(r())
+  tree <- parser_parse(parser, text)
+  node <- tree_root_node(tree)
+
+  expect_snapshot({
+    node_show_s_expression(node)
+  })
+})
+
+test_that("Anonymous `MISSING` nodes are shown", {
+  # Missing `)`
+  text <- "for (i in seq"
+
+  parser <- parser(r())
+  tree <- parser_parse(parser, text)
+  node <- tree_root_node(tree)
+
+  expect_snapshot({
+    node_show_s_expression(node)
+  })
+})


### PR DESCRIPTION
With upstream R grammar patch

Requires https://github.com/r-lib/tree-sitter-r/pull/112