### PR TITLE
Work around non-API in rlang C library

### DIFF
--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -3,8 +3,12 @@
 
 
 bool r_env_binding_is_promise(r_obj* env, r_obj* sym) {
+#if R_BEFORE_NON_API_CLEANUP
   r_obj* obj = r_env_find(env, sym);
   return r_typeof(obj) == R_TYPE_promise && PRVALUE(obj) == r_syms.unbound;
+#else
+  r_stop_internal("Need to analyze `PRVALUE()` usage.");
+#endif
 }
 bool r_env_binding_is_active(r_obj* env, r_obj* sym) {
   return R_BindingIsActive(sym, env);

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -42,9 +42,21 @@ bool r_is_namespace(r_obj* x) {
   return R_IsNamespaceEnv(x);
 }
 
+// TODO: Could consider using new `R_getVarEx()` with `inherits = false`
+// and `ifnotfound = r_syms.unbound`. However, that evaluates promises,
+// so we need to evaluate each usage of `r_env_find()` because the behavior
+// is different.
 static inline
 r_obj* r_env_find(r_obj* env, r_obj* sym) {
+#if R_BEFORE_NON_API_CLEANUP
   return Rf_findVarInFrame3(env, sym, FALSE);
+#else
+  if (R_existsVarInFrame(env, sym)) {
+    return Rf_findVarInFrame(env, sym);
+  } else {
+    return r_syms.unbound;
+  }
+#endif
 }
 static inline
 r_obj* r_env_find_anywhere(r_obj* env, r_obj* sym) {

--- a/src/rlang/fn.h
+++ b/src/rlang/fn.h
@@ -6,27 +6,35 @@ static inline
 r_obj* r_fn_body(r_obj* fn) {
   return BODY_EXPR(fn);
 }
+#if R_BEFORE_NON_API_CLEANUP
 static inline
 void r_fn_poke_body(r_obj* fn, r_obj* body) {
   SET_BODY(fn, body);
 }
+#endif
 
 static inline
 r_obj* r_fn_env(r_obj* fn) {
   return CLOENV(fn);
 }
+#if R_BEFORE_NON_API_CLEANUP
 static inline
 void r_fn_poke_env(r_obj* fn, r_obj* env) {
   SET_CLOENV(fn, env);
 }
+#endif
 
 static inline
 r_obj* r_new_function(r_obj* formals, r_obj* body, r_obj* env) {
+#if R_BEFORE_NON_API_CLEANUP
   SEXP fn = Rf_allocSExp(R_TYPE_closure);
   SET_FORMALS(fn, formals);
   SET_BODY(fn, body);
   SET_CLOENV(fn, env);
   return fn;
+#else
+  return R_mkClosure(formals, body, env);
+#endif
 }
 
 r_obj* r_as_function(r_obj* x, const char* arg);

--- a/src/rlang/obj.h
+++ b/src/rlang/obj.h
@@ -85,11 +85,13 @@ r_obj* r_clone_shared(r_obj* x) {
 r_obj* r_vec_clone(r_obj* x);
 r_obj* r_vec_clone_shared(r_obj* x);
 
+#if R_BEFORE_NON_API_CLEANUP
 static inline
 r_obj* r_poke_type(r_obj* x, enum r_type type) {
   SET_TYPEOF(x, type);
   return x;
 }
+#endif
 
 static inline
 r_obj* r_type_as_string(enum r_type type) {

--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include "rlang-types.h"
 
+#define R_BEFORE_NON_API_CLEANUP (R_VERSION < R_Version(4, 5, 0))
 
 r_obj* r_init_library(r_obj* ns);
 

--- a/src/rlang/vec.c
+++ b/src/rlang/vec.c
@@ -14,7 +14,7 @@ r_obj* r_chr_n(const char* const * strings, r_ssize n) {
   return out;
 }
 
-#if R_VERSION >= R_Version(3, 4, 0)
+#if (R_VERSION >= R_Version(3, 4, 0)) && R_BEFORE_NON_API_CLEANUP
 #define HAS_VIRTUAL_SIZE 1
 #else
 #define HAS_VIRTUAL_SIZE 0

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -47,7 +47,7 @@ const void* r_raw_cbegin(r_obj* x) {
 }
 static inline
 r_obj* const * r_chr_cbegin(r_obj* x) {
-  return (r_obj* const *) STRING_PTR(x);
+  return (r_obj* const *) STRING_PTR_RO(x);
 }
 static inline
 r_obj* const * r_list_cbegin(r_obj* x) {

--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -331,7 +331,11 @@ r_obj* sexp_node_cdr(enum r_type type,
   switch (type) {
   case R_TYPE_closure:     *p_rel = R_SEXP_IT_RELATION_function_body; return BODY(x);
   case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_enclos; return ENCLOS(x);
+#if R_BEFORE_NON_API_CLEANUP
   case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_expr; return PREXPR(x);
+#else
+  case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_expr; r_stop_unreachable();
+#endif
   case R_TYPE_pointer:     *p_rel = R_SEXP_IT_RELATION_pointer_prot; return EXTPTR_PROT(x);
   case R_TYPE_pairlist:
   case R_TYPE_call:

--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -358,7 +358,11 @@ r_obj* sexp_node_tag(enum r_type type,
 #else
   case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_hashtab; r_stop_unreachable();
 #endif
+#if R_BEFORE_NON_API_CLEANUP
   case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_env; return PRENV(x);
+#else
+  case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_env; r_stop_unreachable();
+#endif
   case R_TYPE_pointer:     *p_rel = R_SEXP_IT_RELATION_pointer_tag; return EXTPTR_TAG(x);
   case R_TYPE_pairlist:
   case R_TYPE_call:

--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -349,7 +349,11 @@ r_obj* sexp_node_tag(enum r_type type,
                      enum r_sexp_it_relation* p_rel) {
   switch (type) {
   case R_TYPE_closure:     *p_rel = R_SEXP_IT_RELATION_function_env; return CLOENV(x);
+#if R_BEFORE_NON_API_CLEANUP
   case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_hashtab; return HASHTAB(x);
+#else
+  case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_hashtab; r_stop_unreachable();
+#endif
   case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_env; return PRENV(x);
   case R_TYPE_pointer:     *p_rel = R_SEXP_IT_RELATION_pointer_tag; return EXTPTR_TAG(x);
   case R_TYPE_pairlist:

--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -320,7 +320,11 @@ r_obj* sexp_node_car(enum r_type type,
 #else
   case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_frame; r_stop_unreachable();
 #endif
+#if R_BEFORE_NON_API_CLEANUP
   case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_value; return PRVALUE(x);
+#else
+  case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_value; r_stop_unreachable();
+#endif
   case R_TYPE_pairlist:
   case R_TYPE_call:
   case R_TYPE_dots:        *p_rel = R_SEXP_IT_RELATION_node_car; return CAR(x);

--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -315,7 +315,11 @@ r_obj* sexp_node_car(enum r_type type,
                      enum r_sexp_it_relation* p_rel) {
   switch (type) {
   case R_TYPE_closure:     *p_rel = R_SEXP_IT_RELATION_function_fmls; return FORMALS(x);
+#if R_BEFORE_NON_API_CLEANUP
   case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_frame; return FRAME(x);
+#else
+  case R_TYPE_environment: *p_rel = R_SEXP_IT_RELATION_environment_frame; r_stop_unreachable();
+#endif
   case R_TYPE_promise:     *p_rel = R_SEXP_IT_RELATION_promise_value; return PRVALUE(x);
   case R_TYPE_pairlist:
   case R_TYPE_call:


### PR DESCRIPTION
Either updating with a new tool, or commenting out entirely because treesitter doesn't use the code path.

Search for `R_BEFORE_NON_API_CLEANUP` to find all relevant changes