### PR TITLE
Add `any-` prefix to queries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # treesitter (development version)
 
+* Add [`any-` prefix for query predicates](https://tree-sitter.github.io/tree-sitter/using-parsers#predicates)
+
 # treesitter 0.1.0
 
 * Initial CRAN submission.

--- a/R/query.R
+++ b/R/query.R
@@ -101,6 +101,12 @@ query <- function(language, source) {
 #' Each of these predicates can also be inverted with a `not-` prefix, i.e.
 #' `#not-eq?` and `#not-match?`.
 #'
+#' The equal-string and match predicate can be
+#' prefixed with `any-` which will check if any of the nodes in a capture group
+#' match the string. This is typically used with `(node)+` which selects
+#' multiple nodes and then test if *any* of the node satisfies the predicate
+#' (like [any()]).
+#'
 #' ### String double quotes
 #'
 #' The underlying tree-sitter predicate parser requires that strings supplied
@@ -480,4 +486,12 @@ is_predicate_eq_string <- function(x) {
 
 is_predicate_match_string <- function(x) {
   inherits(x, "tree_sitter_predicate_match_string")
+}
+
+is_predicate_any_match_string <- function(x) {
+  inherits(x, "tree_sitter_predicate_any_match_string")
+}
+
+is_predicate_any_eq_string <- function(x) {
+  inherits(x, "tree_sitter_predicate_any_eq_string")
 }

--- a/man/query-matches-and-captures.Rd
+++ b/man/query-matches-and-captures.Rd
@@ -54,6 +54,12 @@ There are 3 core types of predicates supported:
 
 Each of these predicates can also be inverted with a \verb{not-} prefix, i.e.
 \verb{#not-eq?} and \verb{#not-match?}.
+
+The equal-string and match predicate can be
+prefixed with \verb{any-} which will check if any of the nodes in a capture group
+match the string. This is typically used with \verb{(node)+} which selects
+multiple nodes and then test if \emph{any} of the node satisfies the predicate
+(like \code{\link[=any]{any()}}).
 \subsection{String double quotes}{
 
 The underlying tree-sitter predicate parser requires that strings supplied

--- a/src/decl/query-matches-decl.h
+++ b/src/decl/query-matches-decl.h
@@ -25,7 +25,8 @@ static r_obj* predicate_match(
 static r_obj* predicate_eq_capture(
     uint32_t capture_name_value_id,
     uint32_t capture_value_id,
-    bool capture_invert
+    bool capture_invert,
+    bool capture_any
 );
 
 static bool is_predicate_eq_capture(r_obj* x);
@@ -41,7 +42,8 @@ static r_obj* predicate_eq_string(
     uint32_t capture_name_value_id,
     const char* capture_value,
     uint32_t capture_value_length,
-    bool capture_invert
+    bool capture_invert,
+    bool capture_any
 );
 
 static bool is_predicate_eq_string(r_obj* x);
@@ -57,7 +59,8 @@ static r_obj* predicate_match_string(
     uint32_t capture_name_value_id,
     const char* capture_value,
     uint32_t capture_value_length,
-    bool capture_invert
+    bool capture_invert,
+    bool capture_any
 );
 
 static bool is_predicate_match_string(r_obj* x);


### PR DESCRIPTION
This adds support for the [`any-` prefix for predicates](https://tree-sitter.github.io/tree-sitter/using-parsers#predicates). I've added tests to try and ensure coverage.

Here's an example where I think it's very useful. Find comments that precede an assignment operator and check if any `#' @` comment is included:

``` r
library(treesitter)
library(treesitter.r)
language <- treesitter.r::language()
text <- "
  fn <- function() {}
  fn2 <- function() {}

  #| label: 'test'
  2 + 2
  3^2

  # Adding comment
  fn <- 5

  #' Sum three numbers
  #' @param a Number
  #' @param b Number
  #' @param c Number
  #'
  #' @export
  fn <- function(a, b, c) { a + b + c }
  fn(10, 9, 7)

  #' Sum three numbers
  #' @param a Number
  #' @param b Number
  #' @param c Number
  #'
  #' @export
  fn2 <- function(a, b, c) { a + b + c }

  #' This package blah blah
  #'
  #' @export
  \"packageName\"
"
parser <- parser(language)
tree <- parser_parse(parser, text)
node <- tree_root_node(tree)
source = '
  (
    (comment)* @roxygen
    (binary_operator
      operator: ["<-" "="]
    )
    (#any-match? @roxygen "^#\'\\\\s*\\\\@")
  )
'

query_matches(query(language, source), node)[[1]]
#> [[1]]
#> [[1]]$name
#> [1] "roxygen" "roxygen" "roxygen" "roxygen" "roxygen" "roxygen"
#> 
#> [[1]]$node
#> [[1]]$node[[1]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' Sum three numbers
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(11, 2), (11, 22)])
#> 
#> [[1]]$node[[2]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @param a Number
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(12, 2), (12, 20)])
#> 
#> [[1]]$node[[3]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @param b Number
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(13, 2), (13, 20)])
#> 
#> [[1]]$node[[4]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @param c Number
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(14, 2), (14, 20)])
#> 
#> [[1]]$node[[5]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #'
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(15, 2), (15, 4)])
#> 
#> [[1]]$node[[6]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @export
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(16, 2), (16, 12)])
#> 
#> 
#> 
#> [[2]]
#> [[2]]$name
#> [1] "roxygen" "roxygen" "roxygen" "roxygen" "roxygen" "roxygen"
#> 
#> [[2]]$node
#> [[2]]$node[[1]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' Sum three numbers
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(20, 2), (20, 22)])
#> 
#> [[2]]$node[[2]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @param a Number
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(21, 2), (21, 20)])
#> 
#> [[2]]$node[[3]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @param b Number
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(22, 2), (22, 20)])
#> 
#> [[2]]$node[[4]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @param c Number
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(23, 2), (23, 20)])
#> 
#> [[2]]$node[[5]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #'
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(24, 2), (24, 4)])
#> 
#> [[2]]$node[[6]]
#> <tree_sitter_node>
#> 
#> ── Text ────────────────────────────────────────────────────────────────────────
#> #' @export
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (comment [(25, 2), (25, 12)])
```
