### PR TITLE
Ensure `#eq?` performs an exact equality check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # treesitter (development version)
 
+* Fixed an issue with `#eq?` predicates where extra partial matches could be returned (#28).
+
 * New `query_end_byte_for_pattern()` (#22).
 
 * Updated to [tree-sitter v0.23.0](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.23.0) (#23).

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,7 +28,12 @@ bool r_int_any_missing(r_obj* x);
 bool r_chr_any_missing(r_obj* x);
 
 bool str_equal(const char* x, const char* y);
-bool str_equal_up_to(const char* x, const char* y, size_t n);
+bool str_equal_sized(
+    const char* x,
+    const char* y,
+    size_t x_size,
+    size_t y_size
+);
 
 static inline uint32_t r_uint32_max(uint32_t x, uint32_t y) {
     return (x > y) ? x : y;


### PR DESCRIPTION
Closes https://github.com/DavisVaughan/r-tree-sitter/issues/28

Tricky non nul terminated C strings!

CC @MilesMcBain - also I apologize for the suboptimal help docs of `query_matches()` 😬, definitely need some examples and more explanation of how to use those useful features.