### PR TITLE
Add more `R_BEFORE_NON_API_CLEANUP` usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Updated to [tree-sitter v0.23.0](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.23.0) (#23).
 
+* Removed usage of non-API C calls (#33).
+
 # treesitter 0.1.0
 
 * Initial CRAN submission.

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -26,7 +26,11 @@ r_obj* r_env_parent(r_obj* env) {
   if (env == r_envs.empty) {
     r_stop_internal("Can't take the parent of the empty environment.");
   }
+  #if R_BEFORE_NON_API_CLEANUP
   return ENCLOS(env);
+  #else
+  return R_ParentEnv(env);
+  #endif
 }
 static inline
 void r_env_poke_parent(r_obj* env, r_obj* new_parent) {

--- a/src/rlang/fn.h
+++ b/src/rlang/fn.h
@@ -1,23 +1,22 @@
 #ifndef RLANG_FN_H
 #define RLANG_FN_H
 
-
+#if R_BEFORE_NON_API_CLEANUP
 static inline
 r_obj* r_fn_body(r_obj* fn) {
   return BODY_EXPR(fn);
 }
-#if R_BEFORE_NON_API_CLEANUP
 static inline
 void r_fn_poke_body(r_obj* fn, r_obj* body) {
   SET_BODY(fn, body);
 }
 #endif
 
+#if R_BEFORE_NON_API_CLEANUP
 static inline
 r_obj* r_fn_env(r_obj* fn) {
   return CLOENV(fn);
 }
-#if R_BEFORE_NON_API_CLEANUP
 static inline
 void r_fn_poke_env(r_obj* fn, r_obj* env) {
   SET_CLOENV(fn, env);

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -29,7 +29,9 @@
 #include "vec-chr.c"
 #include "vec-lgl.c"
 #include "vendor.c"
+#if R_BEFORE_NON_API_CLEANUP
 #include "walk.c"
+#endif
 
 
 // Allows long vectors to be indexed with doubles


### PR DESCRIPTION
To avoid new non-API that have cropped up since the last release