### PR TITLE
Try to appease rchk

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -390,7 +390,8 @@ r_obj* r_exec_new_node(TSNode x, r_obj* tree) {
     raw_sym = r_sym("raw");
     tree_sym = r_sym("tree");
 
-    // rchk seems to think this can be a freshly allocated SEXP, but I disagree
+    // Technically can allocate (may get a fresh object with a user database or
+    // active binding) even though it won't here, but rchk will complain
     r_obj* ns = KEEP(r_env_find(R_NamespaceRegistry, r_sym("treesitter")));
 
     r_obj* fn = r_env_find(ns, r_sym("new_node"));

--- a/src/node.c
+++ b/src/node.c
@@ -390,7 +390,8 @@ r_obj* r_exec_new_node(TSNode x, r_obj* tree) {
     raw_sym = r_sym("raw");
     tree_sym = r_sym("tree");
 
-    r_obj* ns = r_env_find(R_NamespaceRegistry, r_sym("treesitter"));
+    // rchk seems to think this can be a freshly allocated SEXP, but I disagree
+    r_obj* ns = KEEP(r_env_find(R_NamespaceRegistry, r_sym("treesitter")));
 
     r_obj* fn = r_env_find(ns, r_sym("new_node"));
     call = r_call3(fn, raw_sym, tree_sym);
@@ -398,6 +399,8 @@ r_obj* r_exec_new_node(TSNode x, r_obj* tree) {
 
     env = r_alloc_environment(2, ns);
     r_preserve(env);
+
+    FREE(1);
   }
 
   r_env_poke(env, raw_sym, ts_node_as_raw(x));

--- a/src/query-matches.c
+++ b/src/query-matches.c
@@ -87,7 +87,10 @@ r_obj* ffi_query_matches(
 
     const r_ssize count = (r_ssize) match.capture_count;
 
-    r_obj* elt = r_alloc_list(2);
+    // Because we don't call `SET_VECTOR_ELT()` directly and instead call it
+    // through `r_dyn_list_push_back()`, rchk gets confused and thinks `elt`
+    // isn't protected, even though it definitely is. See PR #34 for more.
+    r_obj* elt = KEEP(r_alloc_list(2));
     r_dyn_list_push_back(p_pattern, elt);
     r_attrib_poke_names(elt, elt_names);
 
@@ -102,6 +105,8 @@ r_obj* ffi_query_matches(
       r_chr_poke(names, i, v_capture_names[capture.index]);
       r_list_poke(nodes, i, r_exec_new_node(capture.node, ffi_tree));
     }
+
+    FREE(1);
   }
 
   ts_query_cursor_delete(cursor);

--- a/src/query-matches.c
+++ b/src/query-matches.c
@@ -87,9 +87,7 @@ r_obj* ffi_query_matches(
 
     const r_ssize count = (r_ssize) match.capture_count;
 
-    // rchk seems to think we need to protect `elt`, even though
-    // `r_dyn_list_push_back()` definitely protects it, annoying!
-    r_obj* elt = KEEP(r_alloc_list(2));
+    r_obj* elt = r_alloc_list(2);
     r_dyn_list_push_back(p_pattern, elt);
     r_attrib_poke_names(elt, elt_names);
 
@@ -104,8 +102,6 @@ r_obj* ffi_query_matches(
       r_chr_poke(names, i, v_capture_names[capture.index]);
       r_list_poke(nodes, i, r_exec_new_node(capture.node, ffi_tree));
     }
-
-    FREE(1);
   }
 
   ts_query_cursor_delete(cursor);

--- a/src/query-matches.c
+++ b/src/query-matches.c
@@ -87,7 +87,9 @@ r_obj* ffi_query_matches(
 
     const r_ssize count = (r_ssize) match.capture_count;
 
-    r_obj* elt = r_alloc_list(2);
+    // rchk seems to think we need to protect `elt`, even though
+    // `r_dyn_list_push_back()` definitely protects it, annoying!
+    r_obj* elt = KEEP(r_alloc_list(2));
     r_dyn_list_push_back(p_pattern, elt);
     r_attrib_poke_names(elt, elt_names);
 
@@ -102,6 +104,8 @@ r_obj* ffi_query_matches(
       r_chr_poke(names, i, v_capture_names[capture.index]);
       r_list_poke(nodes, i, r_exec_new_node(capture.node, ffi_tree));
     }
+
+    FREE(1);
   }
 
   ts_query_cursor_delete(cursor);

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -125,14 +125,16 @@ static inline
 void r_dyn_raw_poke(struct r_dyn_array* p_vec, r_ssize i, char value) {
   ((char*) p_vec->v_data)[i] = value;
 }
-static inline
-void r_dyn_chr_poke(struct r_dyn_array* p_vec, r_ssize i, r_obj* value) {
-  r_chr_poke(p_vec->data, i, value);
-}
-static inline
-void r_dyn_list_poke(struct r_dyn_array* p_vec, r_ssize i, r_obj* value) {
-  r_list_poke(p_vec->data, i, value);
-}
+
+// Macro to inline `SET_STRING_ELT()` and `SET_VECTOR_ELT()` to avoid rchk false
+// positive.
+#define r_dyn_chr_poke(P_VEC, I, VALUE) do { \
+    r_chr_poke((P_VEC)->data, I, VALUE);     \
+} while (0)
+
+#define r_dyn_list_poke(P_VEC, I, VALUE) do { \
+    r_list_poke((P_VEC)->data, I, VALUE);     \
+} while (0)
 
 static inline
 void* const * r_dyn_pop_back(struct r_dyn_array* p_arr) {
@@ -173,19 +175,25 @@ void r_dyn_cpl_push_back(struct r_dyn_array* p_vec, r_complex elt) {
   r_ssize loc = r__dyn_increment(p_vec);
   r_dyn_cpl_poke(p_vec, loc, elt);
 }
-static inline
-void r_dyn_chr_push_back(struct r_dyn_array* p_vec, r_obj* elt) {
-  KEEP(elt);
-  r_ssize loc = r__dyn_increment(p_vec);
-  r_dyn_chr_poke(p_vec, loc, elt);
-  FREE(1);
-}
-static inline
-void r_dyn_list_push_back(struct r_dyn_array* p_vec, r_obj* elt) {
-  KEEP(elt);
-  r_ssize loc = r__dyn_increment(p_vec);
-  r_dyn_list_poke(p_vec, loc, elt);
-  FREE(1);
-}
+
+// Macro to inline `SET_STRING_ELT()` and `SET_VECTOR_ELT()` to avoid rchk false
+// positive. Careful to avoid double evaluation of arguments.
+#define r_dyn_chr_push_back(P_VEC, ELT) do { \
+  struct r_dyn_array* __p_vec = (P_VEC);     \
+  r_obj* __elt = (ELT);                      \
+  KEEP(__elt);                               \
+  r_ssize __loc = r__dyn_increment(__p_vec); \
+  r_dyn_chr_poke(__p_vec, __loc, __elt);     \
+  FREE(1);                                   \
+} while (0)
+
+#define r_dyn_list_push_back(P_VEC, ELT) do { \
+  struct r_dyn_array* __p_vec = (P_VEC);      \
+  r_obj* __elt = (ELT);                       \
+  KEEP(__elt);                                \
+  r_ssize __loc = r__dyn_increment(__p_vec);  \
+  r_dyn_list_poke(__p_vec, __loc, __elt);     \
+  FREE(1);                                    \
+} while (0)
 
 #endif

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -125,16 +125,14 @@ static inline
 void r_dyn_raw_poke(struct r_dyn_array* p_vec, r_ssize i, char value) {
   ((char*) p_vec->v_data)[i] = value;
 }
-
-// Macro to inline `SET_STRING_ELT()` and `SET_VECTOR_ELT()` to avoid rchk false
-// positive.
-#define r_dyn_chr_poke(P_VEC, I, VALUE) do { \
-  r_chr_poke((P_VEC)->data, I, VALUE);       \
-} while (0)
-
-#define r_dyn_list_poke(P_VEC, I, VALUE) do { \
-  r_list_poke((P_VEC)->data, I, VALUE);       \
-} while (0)
+static inline
+void r_dyn_chr_poke(struct r_dyn_array* p_vec, r_ssize i, r_obj* value) {
+  r_chr_poke(p_vec->data, i, value);
+}
+static inline
+void r_dyn_list_poke(struct r_dyn_array* p_vec, r_ssize i, r_obj* value) {
+  r_list_poke(p_vec->data, i, value);
+}
 
 static inline
 void* const * r_dyn_pop_back(struct r_dyn_array* p_arr) {
@@ -175,25 +173,19 @@ void r_dyn_cpl_push_back(struct r_dyn_array* p_vec, r_complex elt) {
   r_ssize loc = r__dyn_increment(p_vec);
   r_dyn_cpl_poke(p_vec, loc, elt);
 }
-
-// Macro to inline `SET_STRING_ELT()` and `SET_VECTOR_ELT()` to avoid rchk false
-// positive. Careful to avoid double evaluation of arguments.
-#define r_dyn_chr_push_back(P_VEC, ELT) do { \
-  struct r_dyn_array* __p_vec = (P_VEC);     \
-  r_obj* __elt = (ELT);                      \
-  KEEP(__elt);                               \
-  r_ssize __loc = r__dyn_increment(__p_vec); \
-  r_dyn_chr_poke(__p_vec, __loc, __elt);     \
-  FREE(1);                                   \
-} while (0)
-
-#define r_dyn_list_push_back(P_VEC, ELT) do { \
-  struct r_dyn_array* __p_vec = (P_VEC);      \
-  r_obj* __elt = (ELT);                       \
-  KEEP(__elt);                                \
-  r_ssize __loc = r__dyn_increment(__p_vec);  \
-  r_dyn_list_poke(__p_vec, __loc, __elt);     \
-  FREE(1);                                    \
-} while (0)
+static inline
+void r_dyn_chr_push_back(struct r_dyn_array* p_vec, r_obj* elt) {
+  KEEP(elt);
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_chr_poke(p_vec, loc, elt);
+  FREE(1);
+}
+static inline
+void r_dyn_list_push_back(struct r_dyn_array* p_vec, r_obj* elt) {
+  KEEP(elt);
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_list_poke(p_vec, loc, elt);
+  FREE(1);
+}
 
 #endif

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -129,11 +129,11 @@ void r_dyn_raw_poke(struct r_dyn_array* p_vec, r_ssize i, char value) {
 // Macro to inline `SET_STRING_ELT()` and `SET_VECTOR_ELT()` to avoid rchk false
 // positive.
 #define r_dyn_chr_poke(P_VEC, I, VALUE) do { \
-    r_chr_poke((P_VEC)->data, I, VALUE);     \
+  r_chr_poke((P_VEC)->data, I, VALUE);       \
 } while (0)
 
 #define r_dyn_list_poke(P_VEC, I, VALUE) do { \
-    r_list_poke((P_VEC)->data, I, VALUE);     \
+  r_list_poke((P_VEC)->data, I, VALUE);       \
 } while (0)
 
 static inline


### PR DESCRIPTION
```
Package treesitter version 0.1.0
Package built using 87687/R 4.5.0; x86_64-pc-linux-gnu; 2025-02-06 00:23:21 UTC; unix   
Checked with rchk version 35618ebbccf3cd0b45a3530e6303970a22a9056b LLVM version 14.0.6
More information at https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md
For rchk in docker image see https://github.com/kalibera/rchk/blob/master/doc/DOCKER.md

Function ffi_query_matches
  [UP] unprotected variable elt while calling allocating function r_alloc_character.369 treesitter/src/query-matches.c:94
  [UP] unprotected variable elt while calling allocating function r_alloc_list.361 treesitter/src/query-matches.c:97
  [UP] unprotected variable names while calling allocating function r_alloc_list.361 treesitter/src/query-matches.c:97
  [UP] unprotected variable names while calling allocating function r_exec_new_node treesitter/src/query-matches.c:103
  [UP] unprotected variable nodes while calling allocating function r_exec_new_node treesitter/src/query-matches.c:103

Function r_exec_new_node
  [UP] allocating function r_env_find may destroy its unprotected argument (ns <arg 1>), which is later used. treesitter/src/node.c:395
  [UP] calling allocating function r_env_find with a fresh pointer (ns <arg 1>) treesitter/src/node.c:395
  [UP] unprotected variable ns while calling allocating function r_sym treesitter/src/node.c:395
  [UP] unprotected variable ns while calling allocating function Rf_lang3 treesitter/src/node.c:396
  [UP] unprotected variable ns while calling allocating function R_PreserveObject treesitter/src/node.c:397
  [UP] unprotected variable ns while calling allocating function _r_preserve treesitter/src/node.c:397
```

## r_env_find()

rchk thinks `r_env_find()` may allocate a fresh object (`ns`), I don't think it does in this particular case, but see https://github.com/kalibera/rchk/issues/36#issuecomment-2450203705

I think it's correct to just protect here

## r_dyn_list_push_back()

This one is a giant pain in the butt.

`r_dyn_list_push_back()` is a "real" function. It eventually calls `SET_VECTOR_ELT()` to store `elt`, but because `r_dyn_list_push_back()` is a real function there is some indirection between where `elt` is defined and where it is protected by `SET_VECTOR_ELT()`. This indirection causes rchk to think `elt` isn't actually protected, so when we try and use it later on (when we set `names` on it), rchk throws an error.

In rlang, `r_list_poke()` is defined as a macro for `SET_VECTOR_ELT()` to avoid this issue entirely. We thought maybe we could do that here as well by making `r_dyn_list_push_back()` and `r_dyn_list_poke()` macros as well, but it's complicated.

This was our first choice, but it doesn't work because `__elt` looks like a different object than `ELT` (which is `elt`) to rchk, so even though we call `SET_VECTOR_ELT()` on `__elt`, the original `elt` still looks unprotected to rchk.

```
#define r_dyn_list_push_back(P_VEC, ELT) do { \
  struct r_dyn_array* __p_vec = (P_VEC);      \
  r_obj* __elt = (ELT);                       \
  KEEP(__elt);                                \
  r_ssize __loc = r__dyn_increment(__p_vec);  \
  r_dyn_list_poke(__p_vec, __loc, __elt);     \
  FREE(1);                                    \
} while (0)
```

This was another option, but it's a huge footgun. We want to avoid double evaluation of `ELT`, which we do in the above version, but don't here. We commonly call this kind of function with something like `r_dyn_list_push_back(p_nodes, r_exec_new_node(capture.node, ffi_tree))`, which means `r_exec_new_node()` would be evaluated twice, so that rules this out.

```
#define r_dyn_list_push_back(P_VEC, ELT) do { \
  KEEP(ELT);                                  \
  r_ssize __loc = r__dyn_increment(P_VEC);    \
  r_dyn_list_poke(P_VEC, __loc, ELT);         \
  FREE(1);                                    \
} while (0)
```

Really I think this is a limitation of the rchk system. The best we can do is protect and document why we have to do so.