### PR TITLE
Avoid `ATTRIB()` and `SET_ATTRIB()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # treesitter (development version)
 
+* Removed usage of non-API `ATTRIB()` and `SET_ATTRIB()` (#41).
+
 # treesitter 0.3.0
 
 * New `node_field_name_for_named_child()` (#35).

--- a/src/rlang/attrib.h
+++ b/src/rlang/attrib.h
@@ -12,6 +12,7 @@ static inline
 r_obj* r_attrib(r_obj* x) {
   // return ATTRIB(x);
 #ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
+  // We just avoid this completely in treesitter
   Rf_error("Need to analyze `r_attrib()` usage in rlang first.");
 #else
   Rf_error("Need to analyze `r_attrib()` usage in rlang first.");
@@ -19,8 +20,14 @@ r_obj* r_attrib(r_obj* x) {
 }
 static inline
 r_obj* r_poke_attrib(r_obj* x, r_obj* attrs) {
-  SET_ATTRIB(x, attrs);
-  return x;
+  // SET_ATTRIB(x, attrs);
+  // return x;
+#ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
+  // We just avoid this completely in treesitter
+  Rf_error("Need to analyze `r_poke_attrib()` usage in rlang first.");
+#else
+  Rf_error("Need to analyze `r_poke_attrib()` usage in rlang first.");
+#endif
 }
 
 // Unlike Rf_getAttrib(), this never allocates. This also doesn't bump

--- a/src/rlang/attrib.h
+++ b/src/rlang/attrib.h
@@ -10,7 +10,12 @@
 
 static inline
 r_obj* r_attrib(r_obj* x) {
-  return ATTRIB(x);
+  // return ATTRIB(x);
+#ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
+  Rf_error("Need to analyze `r_attrib()` usage in rlang first.");
+#else
+  Rf_error("Need to analyze `r_attrib()` usage in rlang first.");
+#endif
 }
 static inline
 r_obj* r_poke_attrib(r_obj* x, r_obj* attrs) {

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -10,8 +10,15 @@ r_obj* attribs_dyn_array = NULL;
 struct r_dyn_array* r_new_dyn_vector(enum r_type type,
                                      r_ssize capacity) {
   r_obj* shelter = KEEP(r_alloc_list(2));
-  r_poke_attrib(shelter, attribs_dyn_array);
-  r_mark_object(shelter);
+#ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
+  // No reason to not just use `r_attrib_poke_class()` everywhere.
+  // This is likely what we will just do in rlang too.
+  // r_poke_attrib(shelter, attribs_dyn_array);
+  // r_mark_object(shelter);
+  r_attrib_poke_class(shelter, r_chr("rlang_dyn_array"));
+#else
+  r_attrib_poke_class(shelter, r_chr("rlang_dyn_array"));
+#endif
 
   r_obj* vec_raw = r_alloc_raw(sizeof(struct r_dyn_array));
   r_list_poke(shelter, 0, vec_raw);


### PR DESCRIPTION
By just disabling the rlang functions and patching up the one place we transiently call it through dyn-array