### PR TITLE
Use up to date rlang C library

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^LICENSE\.md$
 .clang-format
+.clangd
 .cache
 ^\.vscode$
 compile_commands.json

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # treesitter (development version)
 
+* Removed usage of more non-API C functions.
+
 # treesitter 0.3.1
 
 * Removed usage of non-API `ATTRIB()` and `SET_ATTRIB()` (#41).

--- a/src/node.c
+++ b/src/node.c
@@ -402,9 +402,9 @@ r_obj* r_exec_new_node(TSNode x, r_obj* tree) {
 
     // Technically can allocate (may get a fresh object with a user database or
     // active binding) even though it won't here, but rchk will complain
-    r_obj* ns = KEEP(r_env_find(R_NamespaceRegistry, r_sym("treesitter")));
+    r_obj* ns = KEEP(r_env_get(R_NamespaceRegistry, r_sym("treesitter")));
 
-    r_obj* fn = r_env_find(ns, r_sym("new_node"));
+    r_obj* fn = r_env_get(ns, r_sym("new_node"));
     call = r_call3(fn, raw_sym, tree_sym);
     r_preserve(call);
 
@@ -414,8 +414,8 @@ r_obj* r_exec_new_node(TSNode x, r_obj* tree) {
     FREE(1);
   }
 
-  r_env_poke(env, raw_sym, ts_node_as_raw(x));
-  r_env_poke(env, tree_sym, tree);
+  r_env_bind(env, raw_sym, ts_node_as_raw(x));
+  r_env_bind(env, tree_sym, tree);
 
   return r_eval(call, env);
 }

--- a/src/query-matches.c
+++ b/src/query-matches.c
@@ -814,7 +814,7 @@ static bool r_grepl(r_obj* x, r_obj* pattern) {
     x_sym = r_sym("x");
     pattern_sym = r_sym("pattern");
 
-    SEXP fn = r_env_find(r_envs.base, r_sym("grepl"));
+    SEXP fn = r_env_get(r_envs.base, r_sym("grepl"));
     call = r_call3(fn, pattern_sym, x_sym);
     r_preserve(call);
 
@@ -822,8 +822,8 @@ static bool r_grepl(r_obj* x, r_obj* pattern) {
     r_preserve(env);
   }
 
-  r_env_poke(env, x_sym, x);
-  r_env_poke(env, pattern_sym, pattern);
+  r_env_bind(env, x_sym, x);
+  r_env_bind(env, pattern_sym, pattern);
 
   r_obj* out = KEEP(r_eval(call, env));
 

--- a/src/rlang/attrib.c
+++ b/src/rlang/attrib.c
@@ -1,120 +1,37 @@
 #include "rlang.h"
 
-/**
- * - If `sentinel` is found in the first node: `parent_out` is `r_null`
- * - If `sentinel` is not found: both return value and `parent_out`
- *   are `r_null`
- * - If `sentinel` is `r_null`, this is like a full shallow duplication
- *   but returns tail node
- */
-r_obj* r_pairlist_clone_until(r_obj* node, r_obj* sentinel, r_obj** parent_out) {
-  r_obj* parent = r_null;
-  r_obj* cur = node;
-  int n_kept = 0;
-
-  while (true) {
-    if (cur == sentinel) {
-      FREE(n_kept);
-      *parent_out = parent;
-      return node;
-    }
-    // Return NULL if sentinel is not found
-    if (cur == r_null) {
-      FREE(n_kept);
-      *parent_out = r_null;
-      return r_null;
-    }
-
-    r_obj* tag = r_node_tag(cur);
-    cur = r_new_node(r_node_car(cur), r_node_cdr(cur));
-    r_node_poke_tag(cur, tag);
-
-    if (parent == r_null) {
-      KEEP_N(cur, &n_kept);
-      node = cur;
-    } else {
-      r_node_poke_cdr(parent, cur);
-    }
-
-    parent = cur;
-    cur = r_node_cdr(cur);
+static r_obj* r_attrib_get_cb(r_obj* tag, r_obj* val, void* data) {
+  if (tag == *(r_obj**) data) {
+    return val;
   }
-
-  r_stop_unreachable();
+  return NULL;
 }
 
-
-r_obj* r_attrs_set_at(r_obj* attrs, r_obj* node, r_obj* value) {
-  r_obj* sentinel = r_node_cdr(node);
-  r_obj* new_node = r_null;
-
-  attrs = KEEP(r_pairlist_clone_until(attrs, sentinel, &new_node));
-  r_node_poke_car(new_node, value);
-
-  FREE(1);
-  return attrs;
-}
-r_obj* r_attrs_zap_at(r_obj* attrs, r_obj* node, r_obj* value) {
-  r_obj* sentinel = node;
-  r_obj* new_node = r_null;
-
-  attrs = KEEP(r_pairlist_clone_until(attrs, sentinel, &new_node));
-
-  if (new_node == r_null) {
-    // `node` is the first node of `attrs`
-    attrs = r_node_cdr(attrs);
-  } else {
-    r_node_poke_cdr(new_node, r_node_cdr(node));
-  }
-
-  FREE(1);
-  return attrs;
-}
-r_obj* r_clone2(r_obj* x) {
-  r_obj* attrs = KEEP(r_attrib(x));
-
-  // Prevent attributes from being cloned
-  r_poke_attrib(x, r_null);
-  r_obj* out = r_clone(x);
-  r_poke_attrib(x, attrs);
-  r_poke_attrib(out, attrs);
-
-  FREE(1);
-  return out;
+r_obj* r_attrib_get(r_obj* x, r_obj* tag) {
+  r_obj* out = r_attrib_map(x, &r_attrib_get_cb, &tag);
+  return out ? out : r_null;
 }
 
-r_obj* r_attrib_set(r_obj* x, r_obj* tag, r_obj* value) {
-  r_obj* attrs = r_attrib(x);
-  r_obj* out = KEEP(r_clone2(x));
+// Collect attributes into a pairlist using `R_mapAttrib`
+static r_obj* r_attrib_collect_cb(r_obj* tag, r_obj* val, void* data) {
+  r_obj** p_tail = (r_obj**) data;
 
-  r_obj* node = attrs;
-  while (node != r_null) {
-    if (r_node_tag(node) == tag) {
-      if (value == r_null) {
-        attrs = r_attrs_zap_at(attrs, node, value);
-      } else {
-        attrs = r_attrs_set_at(attrs, node, value);
-      }
-      r_poke_attrib(out, attrs);
+  r_obj* node = r_new_node(val, r_null);
+  r_node_poke_tag(node, tag);
+  r_node_poke_cdr(*p_tail, node);
 
-      FREE(1);
-      return out;
-    }
+  *p_tail = node;
+  return NULL;
+}
 
-    node = r_node_cdr(node);
-  }
+r_obj* r_attrib_collect(r_obj* x) {
+  r_obj* sentinel = KEEP(r_new_node(r_null, r_null));
+  r_obj* tail = sentinel;
 
-  if (value != r_null) {
-    // Just add to the front if attribute does not exist yet
-    attrs = KEEP(r_new_node(out, attrs));
-    r_node_poke_tag(attrs, tag);
-    r_node_poke_car(attrs, value);
-    r_poke_attrib(out, attrs);
-    FREE(1);
-  }
+  r_attrib_map(x, &r_attrib_collect_cb, &tail);
 
   FREE(1);
-  return out;
+  return r_node_cdr(sentinel);
 }
 
 bool r_is_named(r_obj* x) {

--- a/src/rlang/attrib.h
+++ b/src/rlang/attrib.h
@@ -5,84 +5,70 @@
 
 #include "rlang-types.h"
 #include "globals.h"
-#include "node.h"
 
 
 static inline
-r_obj* r_attrib(r_obj* x) {
-  // return ATTRIB(x);
-#ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
-  // We just avoid this completely in treesitter
-  Rf_error("Need to analyze `r_attrib()` usage in rlang first.");
-#else
-  Rf_error("Need to analyze `r_attrib()` usage in rlang first.");
-#endif
-}
-static inline
-r_obj* r_poke_attrib(r_obj* x, r_obj* attrs) {
-  // SET_ATTRIB(x, attrs);
-  // return x;
-#ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
-  // We just avoid this completely in treesitter
-  Rf_error("Need to analyze `r_poke_attrib()` usage in rlang first.");
-#else
-  Rf_error("Need to analyze `r_poke_attrib()` usage in rlang first.");
-#endif
+bool r_attrib_has_any(r_obj* x) {
+  return ANY_ATTRIB(x);
 }
 
-// Unlike Rf_getAttrib(), this never allocates. This also doesn't bump
-// refcounts or namedness.
+// Collect attributes into a fresh pairlist
+r_obj* r_attrib_collect(r_obj* x);
+
+typedef r_obj* (r_attrib_map_fn)(r_obj* tag, r_obj* value, void* data);
+
+// Map a callback to each attribute of an object. Prefer this to collecting for
+// performance-critical applications.
 static inline
-r_obj* r_attrib_get(r_obj* x, r_obj* tag) {
-  return r_pairlist_get(r_attrib(x), tag);
-}
-static inline
-void r_attrib_poke(r_obj* x, r_obj* sym, r_obj* value) {
-  Rf_setAttrib(x, sym, value);
+r_obj* r_attrib_map(r_obj* x, r_attrib_map_fn* fn, void* data) {
+  return R_mapAttrib(x, fn, data);
 }
 
-r_obj* r_attrib_set(r_obj* x, r_obj* tag, r_obj* value);
+static inline
+void r_attrib_zap(r_obj* x, r_obj* tag) {
+  Rf_setAttrib(x, tag, r_null);
+}
+static inline
+void r_attrib_zap_all(r_obj* x) {
+  CLEAR_ATTRIB(x);
+}
+
+static inline
+void r_attrib_clone_from(r_obj* to, r_obj* from) {
+  SHALLOW_DUPLICATE_ATTRIB(to, from);
+}
+
+
+// Unlike Rf_getAttrib(), this doesn't allocate, but in practice requires
+// protection because rchk considers the return value to be a fresh pointer.
+r_obj* r_attrib_get(r_obj* x, r_obj* tag);
 
 static inline
 r_obj* r_class(r_obj* x) {
   return r_attrib_get(x, r_syms.class_);
 }
-static inline
-void r_attrib_poke_class(r_obj* x, r_obj* classes) {
-  r_attrib_poke(x, r_syms.class_, classes);
-}
+
 void r_attrib_poke_classes(r_obj* x, const char** classes, r_ssize n);
 
 static inline
 r_obj* r_dim(r_obj* x) {
   return r_attrib_get(x, r_syms.dim);
 }
-static inline
-void r_attrib_poke_dim(r_obj* x, r_obj* dim) {
-  r_attrib_poke(x, r_syms.dim, dim);
-}
 
 static inline
 r_obj* r_dim_names(r_obj* x) {
   return r_attrib_get(x, r_syms.dim_names);
-}
-static inline
-void r_attrib_poke_dim_names(r_obj* x, r_obj* dim_names) {
-  r_attrib_poke(x, r_syms.dim_names, dim_names);
 }
 
 static inline
 r_obj* r_names(r_obj* x) {
   return r_attrib_get(x, r_syms.names);
 }
-static inline
-void r_attrib_poke_names(r_obj* x, r_obj* nms) {
-  r_attrib_poke(x, r_syms.names, nms);
-}
 
 bool r_is_named(r_obj* x);
 
 
+// Defined as macros so rchk can see that `X` protects `VALUE`
 #define r_attrib_poke(X, SYM, VALUE) Rf_setAttrib(X, SYM, VALUE)
 #define r_attrib_poke_class(X, VALUE) Rf_setAttrib(X, r_syms.class_, VALUE)
 #define r_attrib_poke_dim(X, VALUE) Rf_setAttrib(X, r_syms.dim, VALUE)

--- a/src/rlang/cnd.c
+++ b/src/rlang/cnd.c
@@ -43,7 +43,7 @@ void r_abort(const char* fmt, ...) {
   // Evaluate in a mask but forward error call to the current frame
   r_obj* frame = KEEP(r_peek_frame());
   r_obj* mask = KEEP(r_alloc_environment(2, frame));
-  r_env_poke(mask, r_syms.error_call_flag, frame);
+  r_env_bind(mask, r_syms.error_call_flag, frame);
 
   struct r_pair args[] = {
     { r_syms.message, message }

--- a/src/rlang/debug.c
+++ b/src/rlang/debug.c
@@ -8,7 +8,7 @@ void r_sexp_inspect(r_obj* x) {
 }
 
 void r_browse(r_obj* x) {
-  r_env_poke(r_envs.global, r_sym(".debug"), x);
+  r_env_bind(r_envs.global, r_sym(".debug"), x);
 
   r_printf("Object saved in `.debug`:\n");
   r_obj_print(x);

--- a/src/rlang/decl/.clangd
+++ b/src/rlang/decl/.clangd
@@ -1,0 +1,7 @@
+# These declaration headers can't be parsed standalone.
+# Disable the error limit so that clang doesn't stop
+# parsing, and suppress all resulting diagnostics.
+CompileFlags:
+  Add: [-ferror-limit=0]
+Diagnostics:
+  Suppress: '*'

--- a/src/rlang/decl/env-binding-decl.h
+++ b/src/rlang/decl/env-binding-decl.h
@@ -1,0 +1,1 @@
+extern r_obj* rlang_ns_env;

--- a/src/rlang/decl/env-decl.h
+++ b/src/rlang/decl/env-decl.h
@@ -20,13 +20,6 @@ static
 r_obj* remove_call;
 
 static
-r_obj* poke_lazy_call;
-
-static
-r_obj* poke_lazy_value_node;
-
-
-static
 r_obj* env2list_call;
 
 static

--- a/src/rlang/decl/walk-decl.h
+++ b/src/rlang/decl/walk-decl.h
@@ -3,7 +3,7 @@ enum sexp_iterator_type sexp_iterator_type(enum r_type type,
                                            r_obj* x);
 
 static inline
-r_obj* sexp_node_attrib(enum r_type type, r_obj* x);
+bool sexp_has_attrib(enum r_type type, r_obj* x);
 
 static inline
 r_obj* sexp_node_car(enum r_type type,

--- a/src/rlang/dots-info.c
+++ b/src/rlang/dots-info.c
@@ -1,0 +1,230 @@
+#include <rlang.h>
+
+#define RLANG_HAS_R_DOTS_API (R_VERSION >= R_Version(4, 6, 0))
+
+#if !RLANG_HAS_R_DOTS_API
+
+static
+bool is_promise(r_obj* x) {
+    return r_typeof(x) == R_TYPE_promise;
+}
+
+static
+r_obj* promise_expr(r_obj* x) {
+    return PREXPR(x);
+}
+
+static
+r_obj* promise_env(r_obj* x) {
+    return PRENV(x);
+}
+
+static
+r_obj* env_dot_find(r_obj* env, r_ssize i) {
+    if (i < 0) {
+        r_abort("indexing '...' with negative index %d", (int) i);
+    }
+
+    r_obj* dots = Rf_findVarInFrame(env, r_syms.dots);
+
+    if (dots == r_syms.unbound) {
+        r_abort("'...' used in an incorrect context");
+    }
+
+    if (dots == r_syms.missing || r_typeof(dots) != R_TYPE_dots) {
+        r_abort("the ... list contains fewer than %d elements", (int) i + 1);
+    }
+
+    for (r_ssize j = 0; j < i; ++j) {
+        dots = r_node_cdr(dots);
+        if (dots == r_null) {
+            r_abort("the ... list contains fewer than %d elements", (int) i + 1);
+        }
+    }
+
+    return r_node_car(dots);
+}
+
+#endif
+
+
+// Dots API - mirrors R-devel PR #209 ---
+// See https://github.com/r-devel/r-svn/pull/209
+
+
+// R API: R_DotsExist
+bool r_env_dots_exist(r_obj* env) {
+#if RLANG_HAS_R_DOTS_API
+    return R_DotsExist(env);
+#else
+    r_obj* dots = Rf_findVarInFrame(env, r_syms.dots);
+    return dots != r_syms.unbound;
+#endif
+}
+
+r_obj* r_env_until_dots(r_obj* env) {
+    while (env != r_envs.empty) {
+        if (r_env_dots_exist(env)) {
+            return env;
+        }
+        env = r_env_parent(env);
+    }
+    return r_envs.empty;
+}
+
+// R API: R_DotsLength
+r_ssize r_env_dots_length(r_obj* env) {
+#if RLANG_HAS_R_DOTS_API
+    return (r_ssize) R_DotsLength(env);
+#else
+    r_obj* dots = Rf_findVarInFrame(env, r_syms.dots);
+
+    if (dots == r_syms.unbound) {
+        r_abort("incorrect context: the current call has no '...' to look in");
+    }
+
+    if (dots == r_syms.missing || r_typeof(dots) != R_TYPE_dots) {
+        return 0;
+    }
+
+    return r_length(dots);
+#endif
+}
+
+// R API: R_DotsNames
+// Returns NULL when all dots are unnamed.
+r_obj* r_env_dots_names(r_obj* env) {
+#if RLANG_HAS_R_DOTS_API
+    return R_DotsNames(env);
+#else
+    r_obj* dots = KEEP(Rf_findVarInFrame(env, r_syms.dots));
+
+    if (dots == r_syms.unbound) {
+        r_abort("incorrect context: the current call has no '...' to look in");
+    }
+
+    r_ssize n = (dots == r_syms.missing || r_typeof(dots) != R_TYPE_dots) ? 0 : r_length(dots);
+
+    r_obj* out = r_null;
+
+    for (r_ssize i = 0; i < n; ++i) {
+        r_obj* tag = r_node_tag(dots);
+        if (r_typeof(tag) == R_TYPE_symbol) {
+            if (out == r_null) {
+                out = KEEP(r_alloc_character(n));
+            }
+            r_chr_poke(out, i, r_sym_string(tag));
+        }
+        dots = r_node_cdr(dots);
+    }
+
+    if (out != r_null) {
+        FREE(1);
+    }
+
+    FREE(1);
+    return out;
+#endif
+}
+
+// R API: R_DotsElt
+r_obj* r_env_dot_get(r_obj* env, r_ssize i) {
+    if (r_env_dot_type(env, i) == DOT_TYPE_missing) {
+        return r_missing_arg;
+    }
+
+#if RLANG_HAS_R_DOTS_API
+    return R_DotsElt((int)(i + 1), env);
+#else
+    r_obj* elt = env_dot_find(env, i);
+    return r_eval(elt, env);
+#endif
+}
+
+// R API: R_GetDotType
+r_dot_type_t r_env_dot_type(r_obj* env, r_ssize i) {
+#if RLANG_HAS_R_DOTS_API
+    return (r_dot_type_t) R_GetDotType((int)(i + 1), env);
+#else
+    r_obj* elt = env_dot_find(env, i);
+
+    if (elt == r_syms.missing) {
+        return DOT_TYPE_missing;
+    }
+
+    if (!is_promise(elt)) {
+        return DOT_TYPE_value;
+    }
+
+    bool forced;
+    rlang_promise_unwrap(elt, &forced);
+    if (forced) {
+        return DOT_TYPE_forced;
+    }
+
+    return DOT_TYPE_delayed;
+#endif
+}
+
+// R API: R_DotDelayedExpression
+r_obj* r_env_dot_delayed_expr(r_obj* env, r_ssize i) {
+#if RLANG_HAS_R_DOTS_API
+    return R_DotDelayedExpression((int)(i + 1), env);
+#else
+    r_obj* elt = env_dot_find(env, i);
+
+    if (!is_promise(elt)) {
+        r_abort("not a delayed ... element");
+    }
+
+    bool forced;
+    r_obj* inner = rlang_promise_unwrap(elt, &forced);
+    if (forced) {
+        r_abort("not a delayed ... element");
+    }
+
+    return promise_expr(inner);
+#endif
+}
+
+// R API: R_DotDelayedEnvironment
+r_obj* r_env_dot_delayed_env(r_obj* env, r_ssize i) {
+#if RLANG_HAS_R_DOTS_API
+    return R_DotDelayedEnvironment((int)(i + 1), env);
+#else
+    r_obj* elt = env_dot_find(env, i);
+
+    if (!is_promise(elt)) {
+        r_abort("not a delayed ... element");
+    }
+
+    bool forced;
+    r_obj* inner = rlang_promise_unwrap(elt, &forced);
+    if (forced) {
+        r_abort("not a delayed ... element");
+    }
+
+    return promise_env(inner);
+#endif
+}
+
+// R API: R_DotForcedExpression
+r_obj* r_env_dot_forced_expr(r_obj* env, r_ssize i) {
+#if RLANG_HAS_R_DOTS_API
+    return R_DotForcedExpression((int)(i + 1), env);
+#else
+    r_obj* elt = env_dot_find(env, i);
+
+    if (!is_promise(elt)) {
+        r_abort("not a forced ... element");
+    }
+
+    bool forced;
+    r_obj* inner = rlang_promise_unwrap(elt, &forced);
+    if (!forced) {
+        r_abort("not a forced ... element");
+    }
+
+    return promise_expr(inner);
+#endif
+}

--- a/src/rlang/dots-info.h
+++ b/src/rlang/dots-info.h
@@ -1,0 +1,26 @@
+#ifndef RLANG_DOTS_INFO_H
+#define RLANG_DOTS_INFO_H
+
+#include "rlang-types.h"
+
+typedef enum {
+    DOT_TYPE_value = 0,
+    DOT_TYPE_missing = 1,
+    DOT_TYPE_delayed = 2,
+    DOT_TYPE_forced = 3
+} r_dot_type_t;
+
+bool r_env_dots_exist(r_obj* env);
+r_ssize r_env_dots_length(r_obj* env);
+r_obj* r_env_dots_names(r_obj* env);
+r_obj* r_env_dot_get(r_obj* env, r_ssize i);
+
+r_dot_type_t r_env_dot_type(r_obj* env, r_ssize i);
+
+r_obj* r_env_dot_delayed_expr(r_obj* env, r_ssize i);
+r_obj* r_env_dot_delayed_env(r_obj* env, r_ssize i);
+r_obj* r_env_dot_forced_expr(r_obj* env, r_ssize i);
+
+r_obj* r_env_until_dots(r_obj* env);
+
+#endif /* RLANG_DOTS_INFO_H */

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -4,21 +4,13 @@
 #define R_DYN_ARRAY_GROWTH_FACTOR 2
 
 static
-r_obj* attribs_dyn_array = NULL;
+r_obj* dyn_array_class = NULL;
 
 
 struct r_dyn_array* r_new_dyn_vector(enum r_type type,
                                      r_ssize capacity) {
   r_obj* shelter = KEEP(r_alloc_list(2));
-#ifdef R_TREESITTER_BEFORE_NON_API_CLEANUP
-  // No reason to not just use `r_attrib_poke_class()` everywhere.
-  // This is likely what we will just do in rlang too.
-  // r_poke_attrib(shelter, attribs_dyn_array);
-  // r_mark_object(shelter);
-  r_attrib_poke_class(shelter, r_chr("rlang_dyn_array"));
-#else
-  r_attrib_poke_class(shelter, r_chr("rlang_dyn_array"));
-#endif
+  r_attrib_poke_class(shelter, dyn_array_class);
 
   r_obj* vec_raw = r_alloc_raw(sizeof(struct r_dyn_array));
   r_list_poke(shelter, 0, vec_raw);
@@ -119,6 +111,5 @@ void r_dyn_resize(struct r_dyn_array* p_arr,
 
 
 void r_init_library_dyn_array(void) {
-  r_preserve_global(attribs_dyn_array = r_pairlist(r_chr("rlang_dyn_array")));
-  r_node_poke_tag(attribs_dyn_array, r_syms.class_);
+  r_preserve_global(dyn_array_class = r_chr("rlang_dyn_array"));
 }

--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -1,18 +1,16 @@
 #include "rlang.h"
 #include "env.h"
+#include "decl/env-binding-decl.h"
 
+// https://bugs.r-project.org/show_bug.cgi?id=18928
+#define RLANG_HAS_R_BINDING_API (R_VERSION >= R_Version(4, 6, 0))
 
-bool r_env_binding_is_promise(r_obj* env, r_obj* sym) {
-#if R_TREESITTER_BEFORE_NON_API_CLEANUP
-  r_obj* obj = r_env_find(env, sym);
-  return r_typeof(obj) == R_TYPE_promise && PRVALUE(obj) == r_syms.unbound;
-#else
-  r_stop_internal("Need to analyze `PRVALUE()` usage.");
+#if !RLANG_HAS_R_BINDING_API
+static inline r_obj* env_find(r_obj* env, r_obj* sym) {
+  return Rf_findVarInFrame3(env, sym, FALSE);
+}
 #endif
-}
-bool r_env_binding_is_active(r_obj* env, r_obj* sym) {
-  return R_BindingIsActive(sym, env);
-}
+
 
 static r_obj* new_binding_types(r_ssize n) {
   r_obj* types = r_alloc_integer(n);
@@ -23,19 +21,7 @@ static r_obj* new_binding_types(r_ssize n) {
   return types;
 }
 
-static enum r_env_binding_type which_env_binding(r_obj* env, r_obj* sym) {
-  if (r_env_binding_is_active(env, sym)) {
-    // Check for active bindings first, since promise detection triggers
-    // active bindings through `r_env_find()` (#1376)
-    return R_ENV_BINDING_TYPE_active;
-  }
 
-  if (r_env_binding_is_promise(env, sym)) {
-    return R_ENV_BINDING_TYPE_promise;
-  }
-
-  return R_ENV_BINDING_TYPE_value;
-}
 
 static inline r_obj* binding_as_sym(bool list, r_obj* bindings, r_ssize i) {
   if (list) {
@@ -58,7 +44,8 @@ static r_ssize detect_special_binding(r_obj* env,
 
   for (r_ssize i = 0; i < n; ++i) {
     r_obj* sym = binding_as_sym(symbols, bindings, i);
-    if (which_env_binding(env, sym)) {
+    enum r_env_binding_type type = r_env_binding_type(env, sym);
+    if (type == R_ENV_BINDING_TYPE_active || type == R_ENV_BINDING_TYPE_delayed) {
       return i;
     }
   }
@@ -86,11 +73,17 @@ r_obj* r_env_binding_types(r_obj* env, r_obj* bindings) {
 
   r_ssize n = r_length(bindings);
   r_obj* types = KEEP(new_binding_types(n));
-  int* types_ptr = r_int_begin(types) + i;
+  int* types_ptr = r_int_begin(types);
+
+  // Fill value type for bindings before first special binding
+  for (r_ssize j = 0; j < i; ++j) {
+    *types_ptr = R_ENV_BINDING_TYPE_value;
+    ++types_ptr;
+  }
 
   while (i < n) {
     r_obj* sym = binding_as_sym(symbols, bindings, i);
-    *types_ptr = which_env_binding(env, sym);
+    *types_ptr = r_env_binding_type(env, sym);
 
     ++i;
     ++types_ptr;
@@ -98,4 +91,207 @@ r_obj* r_env_binding_types(r_obj* env, r_obj* bindings) {
 
   FREE(1);
   return types;
+}
+
+// This does an extra alloc, see https://bugs.r-project.org/show_bug.cgi?id=18928#c2
+r_obj* r_env_syms(r_obj* env) {
+  r_obj* nms = KEEP(r_env_names(env));
+  r_ssize n = r_length(nms);
+
+  r_obj* out = KEEP(r_alloc_list(n));
+  r_obj* const * v_nms = r_chr_cbegin(nms);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    r_list_poke(out, i, r_str_as_symbol(v_nms[i]));
+  }
+
+  FREE(2);
+  return out;
+}
+
+
+// Binding type API
+// Implements future R API from https://bugs.r-project.org/show_bug.cgi?id=18928
+
+enum r_env_binding_type r_env_binding_type(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  switch (R_GetBindingType(sym, env)) {
+  case R_BindingTypeUnbound: return R_ENV_BINDING_TYPE_unbound;
+  case R_BindingTypeValue:   return R_ENV_BINDING_TYPE_value;
+  case R_BindingTypeMissing: return R_ENV_BINDING_TYPE_missing;
+  case R_BindingTypeDelayed: return R_ENV_BINDING_TYPE_delayed;
+  case R_BindingTypeForced:  return R_ENV_BINDING_TYPE_forced;
+  case R_BindingTypeActive:  return R_ENV_BINDING_TYPE_active;
+  }
+  r_stop_unreachable();
+#else
+  // Active binding check must come first since `r_env_find()` triggers them
+  if (R_BindingIsActive(sym, env)) {
+    return R_ENV_BINDING_TYPE_active;
+  }
+
+  r_obj* value = env_find(env, sym);
+
+  if (value == r_syms.unbound) {
+    return R_ENV_BINDING_TYPE_unbound;
+  }
+
+  if (value == r_missing_arg) {
+    return R_ENV_BINDING_TYPE_missing;
+  }
+
+  if (r_typeof(value) == R_TYPE_promise) {
+    bool forced;
+    rlang_promise_unwrap(value, &forced);
+    if (forced) {
+      return R_ENV_BINDING_TYPE_forced;
+    }
+
+    return R_ENV_BINDING_TYPE_delayed;
+  }
+
+  return R_ENV_BINDING_TYPE_value;
+#endif
+}
+
+r_obj* r_env_get(r_obj* env, r_obj* sym) {
+  enum r_env_binding_type type = r_env_binding_type(env, sym);
+
+  if (type == R_ENV_BINDING_TYPE_unbound) {
+    r_abort("object '%s' not found", r_sym_c_string(sym));
+  }
+  if (type == R_ENV_BINDING_TYPE_missing) {
+    return r_missing_arg;
+  }
+
+#if R_VERSION >= R_Version(4, 5, 0)
+  return R_getVar(sym, env, TRUE);
+#else
+  r_obj* value = env_find(env, sym);
+  if (r_typeof(value) == R_TYPE_dots) {
+    return value;
+  }
+
+  // Handles value, delayed, forced, and active bindings
+  return Rf_eval(sym, env);
+#endif
+}
+
+
+// Binding constructors
+
+void r_env_bind_active(r_obj* env, r_obj* sym, r_obj* fn) {
+  KEEP(fn);
+  r_env_unbind(env, sym);
+  R_MakeActiveBinding(sym, fn, env);
+  FREE(1);
+}
+
+void r_env_bind_delayed(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env) {
+#if RLANG_HAS_R_BINDING_API
+  R_MakeDelayedBinding(sym, expr, eval_env, env);
+#else
+  r_obj* promise = KEEP(Rf_allocSExp(PROMSXP));
+  SET_PRCODE(promise, expr);
+  SET_PRENV(promise, eval_env);
+  SET_PRVALUE(promise, r_syms.unbound);
+  Rf_defineVar(sym, promise, env);
+  FREE(1);
+#endif
+}
+
+void r_env_bind_forced(r_obj* env, r_obj* sym, r_obj* expr, r_obj* value) {
+#if RLANG_HAS_R_BINDING_API
+  R_MakeForcedBinding(sym, expr, value, env);
+#else
+  r_obj* promise = KEEP(Rf_allocSExp(PROMSXP));
+  SET_PRCODE(promise, expr);
+  SET_PRENV(promise, r_null);
+  SET_PRVALUE(promise, value);
+  Rf_defineVar(sym, promise, env);
+  FREE(1);
+#endif
+}
+
+void r_env_bind_missing(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  R_MakeMissingBinding(sym, env);
+#else
+  Rf_defineVar(sym, r_missing_arg, env);
+#endif
+}
+
+
+// Delayed binding accessors
+
+r_obj* r_env_binding_delayed_expr(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  return R_DelayedBindingExpression(sym, env);
+#else
+  r_obj* value = env_find(env, sym);
+
+  if (r_typeof(value) != R_TYPE_promise) {
+    r_abort("not a delayed binding");
+  }
+
+  bool forced;
+  r_obj* inner = rlang_promise_unwrap(value, &forced);
+  if (forced) {
+    r_abort("not a delayed binding");
+  }
+
+  return R_PromiseExpr(inner);
+#endif
+}
+
+r_obj* r_env_binding_delayed_env(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  return R_DelayedBindingEnvironment(sym, env);
+#else
+  r_obj* value = env_find(env, sym);
+
+  if (r_typeof(value) != R_TYPE_promise) {
+    r_abort("not a delayed binding");
+  }
+
+  bool forced;
+  r_obj* inner = rlang_promise_unwrap(value, &forced);
+  if (forced) {
+    r_abort("not a delayed binding");
+  }
+
+  return PRENV(inner);
+#endif
+}
+
+
+// Forced binding accessors
+
+r_obj* r_env_binding_forced_expr(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  return R_ForcedBindingExpression(sym, env);
+#else
+  r_obj* value = env_find(env, sym);
+
+  if (r_typeof(value) != R_TYPE_promise) {
+    r_abort("not a forced binding");
+  }
+
+  bool forced;
+  r_obj* inner = rlang_promise_unwrap(value, &forced);
+  if (!forced) {
+    r_abort("not a forced binding");
+  }
+
+  return R_PromiseExpr(inner);
+#endif
+}
+
+// Use `r_env_get()` to get the value of a forced binding
+
+
+// Active binding accessors
+
+r_obj* r_env_binding_active_fn(r_obj* env, r_obj* sym) {
+  return R_ActiveBindingFunction(sym, env);
 }

--- a/src/rlang/env-binding.h
+++ b/src/rlang/env-binding.h
@@ -6,14 +6,52 @@
 #include "rlang-types.h"
 
 enum r_env_binding_type {
-  R_ENV_BINDING_TYPE_value = 0,
-  R_ENV_BINDING_TYPE_promise,
-  R_ENV_BINDING_TYPE_active
+  R_ENV_BINDING_TYPE_unbound = 0,
+  R_ENV_BINDING_TYPE_value = 1,
+  R_ENV_BINDING_TYPE_missing = 2,
+  R_ENV_BINDING_TYPE_delayed = 3,
+  R_ENV_BINDING_TYPE_forced = 4,
+  R_ENV_BINDING_TYPE_active = 5
 };
 
-bool r_env_binding_is_promise(r_obj* env, r_obj* sym);
-bool r_env_binding_is_active(r_obj* env, r_obj* sym);
-r_obj* r_env_binding_types(r_obj* env, r_obj* bindings);
+enum r_env_binding_type r_env_binding_type(r_obj* env, r_obj* sym);
+r_obj* r_env_binding_types(r_obj* env, r_obj* syms);
+
+r_obj* r_env_syms(r_obj* env);
+
+r_obj* r_env_get(r_obj* env, r_obj* sym);
+
+// Binding constructors
+static inline
+void r_env_bind(r_obj* env, r_obj* sym, r_obj* value) {
+  // See rchk concerns in https://github.com/r-lib/rlang/commit/28ce7b01
+  KEEP(value);
+  Rf_defineVar(sym, value, env);
+  FREE(1);
+}
+
+// Silently ignores bindings that are not defined in `env`.
+static inline
+void r_env_unbind(r_obj* env, r_obj* sym) {
+  R_removeVarFromFrame(sym, env);
+}
+
+void r_env_bind_active(r_obj* env, r_obj* sym, r_obj* fn);
+void r_env_bind_delayed(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env);
+void r_env_bind_forced(r_obj* env, r_obj* sym, r_obj* expr, r_obj* value);
+void r_env_bind_missing(r_obj* env, r_obj* sym);
+
+// Delayed binding accessors
+r_obj* r_env_binding_delayed_expr(r_obj* env, r_obj* sym);
+r_obj* r_env_binding_delayed_env(r_obj* env, r_obj* sym);
+
+// Forced binding accessors
+r_obj* r_env_binding_forced_expr(r_obj* env, r_obj* sym);
+
+// Active binding accessors
+r_obj* r_env_binding_active_fn(r_obj* env, r_obj* sym);
+
+void r_init_library_env_binding(void);
 
 
 #endif

--- a/src/rlang/env.c
+++ b/src/rlang/env.c
@@ -65,37 +65,64 @@ r_obj* r_env_clone(r_obj* env, r_obj* parent) {
 }
 
 void r_env_coalesce(r_obj* env, r_obj* from) {
-  r_obj* nms = KEEP(r_env_names(from));
-  r_obj* types = KEEP(r_env_binding_types(from, nms));
+  r_obj* syms = KEEP(r_env_syms(from));
+  r_obj* types = KEEP(r_env_binding_types(from, syms));
 
   if (types == r_null) {
-    env_coalesce_plain(env, from, nms);
+    env_coalesce_plain(env, from, syms);
     FREE(2);
     return;
   }
 
-  r_ssize n = r_length(nms);
-  r_obj* const * v_nms = r_chr_cbegin(nms);
+  r_ssize n = r_length(syms);
+  r_obj* const * v_syms = r_list_cbegin(syms);
   enum r_env_binding_type* v_types = (enum r_env_binding_type*) r_int_begin(types);
 
   for (r_ssize i = 0; i < n; ++i) {
-    r_obj* sym = r_str_as_symbol(v_nms[i]);
+    r_obj* sym = v_syms[i];
 
     if (r_env_has(env, sym)) {
       continue;
     }
 
     switch (v_types[i]) {
-    case R_ENV_BINDING_TYPE_value:
-    case R_ENV_BINDING_TYPE_promise:
-      r_env_poke(env, sym, r_env_find(from, sym));
+    case R_ENV_BINDING_TYPE_unbound:
       break;
 
-    case R_ENV_BINDING_TYPE_active: {
-      r_obj* fn = R_ActiveBindingFunction(sym, from);
-      r_env_poke_active(env, sym, fn);
+    case R_ENV_BINDING_TYPE_value:
+      r_env_bind(env, sym, KEEP(r_env_get(from, sym)));
+      FREE(1);
       break;
-    }}
+
+    case R_ENV_BINDING_TYPE_delayed:
+      r_env_bind_delayed(
+        env,
+        sym,
+        KEEP(r_env_binding_delayed_expr(from, sym)),
+        KEEP(r_env_binding_delayed_env(from, sym))
+      );
+      FREE(2);
+      break;
+
+    case R_ENV_BINDING_TYPE_forced:
+      r_env_bind_forced(
+        env,
+        sym,
+        KEEP(r_env_binding_forced_expr(from, sym)),
+        KEEP(r_env_get(from, sym))
+      );
+      FREE(2);
+      break;
+
+    case R_ENV_BINDING_TYPE_missing:
+      r_env_bind_missing(env, sym);
+      break;
+
+    case R_ENV_BINDING_TYPE_active:
+      r_env_bind_active(env, sym, KEEP(r_env_binding_active_fn(from, sym)));
+      FREE(1);
+      break;
+    }
   }
 
   FREE(2);
@@ -103,18 +130,19 @@ void r_env_coalesce(r_obj* env, r_obj* from) {
 }
 
 static
-void env_coalesce_plain(r_obj* env, r_obj* from, r_obj* nms) {
-  r_ssize n = r_length(nms);
-  r_obj* const * v_nms = r_chr_cbegin(nms);
+void env_coalesce_plain(r_obj* env, r_obj* from, r_obj* syms) {
+  r_ssize n = r_length(syms);
+  r_obj* const * v_syms = r_list_cbegin(syms);
 
   for (r_ssize i = 0; i < n; ++i) {
-    r_obj* sym = r_str_as_symbol(v_nms[i]);
+    r_obj* sym = v_syms[i];
 
     if (r_env_has(env, sym)) {
       continue;
     }
 
-    r_env_poke(env, sym, r_env_find(from, sym));
+    r_env_bind(env, sym, KEEP(r_env_get(from, sym)));
+    FREE(1);
   }
 
   return;
@@ -125,20 +153,12 @@ r_obj* r_list_as_environment(r_obj* x, r_obj* parent) {
   return eval_with_xy(list2env_call, x, parent);
 }
 
-void r_env_poke_lazy(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env) {
-  KEEP(expr);
-  r_obj* name = KEEP(r_sym_as_utf8_character(sym));
-
-  r_node_poke_car(poke_lazy_value_node, expr);
-  r_eval_with_xyz(poke_lazy_call, name, env, eval_env, rlang_ns_env);
-  r_node_poke_car(poke_lazy_value_node, r_null);
-
-  FREE(2);
-}
-
-
 #if RLANG_USE_R_EXISTS
 bool r__env_has(r_obj* env, r_obj* sym) {
+  // `exists("")` errors on older R
+  if (sym == R_MissingArg) {
+    return Rf_findVarInFrame3(env, sym, FALSE) != r_syms.unbound;
+  }
   r_obj* nm = KEEP(r_sym_as_utf8_character(sym));
   r_obj* out = eval_with_xyz(exists_call, env, nm, r_false);
   FREE(1);
@@ -146,6 +166,10 @@ bool r__env_has(r_obj* env, r_obj* sym) {
 }
 
 bool r__env_has_anywhere(r_obj* env, r_obj* sym) {
+  // `exists("")` errors on older R
+  if (sym == R_MissingArg) {
+    return Rf_findVar(sym, env) != r_syms.unbound;
+  }
   r_obj* nm = KEEP(r_sym_as_utf8_character(sym));
   r_obj* out = eval_with_xyz(exists_call, env, nm, r_true);
   FREE(1);
@@ -180,34 +204,41 @@ bool r_env_inherits(r_obj* env, r_obj* ancestor, r_obj* top) {
   return env == ancestor;
 }
 
-static
-r_obj* env_until(r_obj* env, r_obj* sym, r_obj* last) {
+r_obj* r_env_until(r_obj* env, r_obj* sym, r_obj* last) {
   r_obj* stop = r_envs.empty;
   if (last != r_envs.empty) {
     stop = r_env_parent(last);
   }
 
   while (true) {
-    if (env == r_envs.empty || r_env_has(env, sym)) {
+    if (env == r_envs.empty) {
+      return r_envs.empty;
+    }
+    if (r_env_has(env, sym)) {
       return env;
     }
 
     r_obj* next = r_env_parent(env);
     if (next == r_envs.empty || next == stop) {
-      return env;
+      return r_envs.empty;
     }
 
     env = next;
   }
 }
 
+r_obj* r_env_get_anywhere(r_obj* env, r_obj* sym) {
+  env = r_env_until(env, sym, r_envs.empty);
+  return r_env_get(env, sym);
+}
+
 r_obj* r_env_get_until(r_obj* env, r_obj* sym, r_obj* last) {
-  env = env_until(env, sym, last);
+  env = r_env_until(env, sym, last);
   return r_env_get(env, sym);
 }
 
 bool r_env_has_until(r_obj* env, r_obj* sym, r_obj* last) {
-  env = env_until(env, sym, last);
+  env = r_env_until(env, sym, last);
   return r_env_has(env, sym);
 }
 
@@ -240,11 +271,6 @@ void r_init_library_env(void) {
   list2env_call = r_parse("list2env(x, envir = NULL, parent = y, hash = TRUE)");
   r_preserve(list2env_call);
 
-  poke_lazy_call = r_parse("delayedAssign(x, value = NULL, assign.env = y, eval.env = z)");
-  r_preserve(poke_lazy_call);
-
-  poke_lazy_value_node = r_node_cddr(poke_lazy_call);
-
   exists_call = r_parse("exists(y, envir = x, inherits = z)");
   r_preserve(exists_call);
 
@@ -273,12 +299,6 @@ r_obj* exists_call = NULL;
 
 static
 r_obj* remove_call = NULL;
-
-static
-r_obj* poke_lazy_call = NULL;
-
-static
-r_obj* poke_lazy_value_node = NULL;
 
 static
 r_obj* env2list_call = NULL;

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -7,8 +7,6 @@
 #include "cnd.h"
 #include "globals.h"
 #include "obj.h"
-#include "rlang.h"
-#include "sym.h"
 
 #define RLANG_USE_R_EXISTS (R_VERSION < R_Version(4, 2, 0))
 
@@ -50,70 +48,9 @@ bool r_is_namespace(r_obj* x) {
   return R_IsNamespaceEnv(x);
 }
 
-// TODO: Could consider using new `R_getVarEx()` with `inherits = false`
-// and `ifnotfound = r_syms.unbound`. However, that evaluates promises,
-// so we need to evaluate each usage of `r_env_find()` because the behavior
-// is different.
-static inline
-r_obj* r_env_find(r_obj* env, r_obj* sym) {
-#if R_TREESITTER_BEFORE_NON_API_CLEANUP
-  return Rf_findVarInFrame3(env, sym, FALSE);
-#else
-  if (R_existsVarInFrame(env, sym)) {
-    return Rf_findVarInFrame(env, sym);
-  } else {
-    return r_syms.unbound;
-  }
-#endif
-}
-static inline
-r_obj* r_env_find_anywhere(r_obj* env, r_obj* sym) {
-  return Rf_findVar(sym, env);
-}
+r_obj* r_env_until(r_obj* env, r_obj* sym, r_obj* last);
 
-#if 1 || R_VERSION < R_Version(4, 5, 0)
-// We currently can't use `R_getVar()` which:
-// 1. Throws if not found
-// 2. Throws if argument is the missing arg
-// 3. Evaluates promises
-// Our operators have to return missing arguments.
-static inline
-r_obj* r_env_get(r_obj* env, r_obj* sym) {
-  r_obj* out = r_env_find(env, sym);
-
-  if (out == r_syms.unbound) {
-    r_abort("object '%s' not found", r_sym_c_string(sym));
-  }
-
-  if (r_typeof(out) == R_TYPE_promise) {
-    return Rf_eval(out, env);
-  }
-
-  return out;
-}
-
-static inline
-r_obj* r_env_get_anywhere(r_obj* env, r_obj* sym) {
-  r_obj* out = r_env_find_anywhere(env, sym);
-
-  if (out == r_syms.unbound) {
-    r_abort("object '%s' not found", r_sym_c_string(sym));
-  }
-
-  return out;
-}
-#else
-static inline
-r_obj* r_env_get(r_obj* env, r_obj* sym) {
-  return R_getVar(sym, env, FALSE);
-}
-
-static inline
-r_obj* r_env_get_anywhere(r_obj* env, r_obj* sym) {
-  return R_getVar(sym, env, TRUE);
-}
-#endif
-
+r_obj* r_env_get_anywhere(r_obj* env, r_obj* sym);
 r_obj* r_env_get_until(r_obj* env, r_obj* sym, r_obj* last);
 bool r_env_has_until(r_obj* env, r_obj* sym, r_obj* last);
 
@@ -171,29 +108,6 @@ r_obj* r_env_clone(r_obj* env, r_obj* parent);
 
 void r_env_coalesce(r_obj* env, r_obj* from);
 
-
-// Silently ignores bindings that are not defined in `env`.
-static inline
-void r_env_unbind(r_obj* env, r_obj* sym) {
-  R_removeVarFromFrame(sym, env);
-}
-
-static inline
-void r_env_poke(r_obj* env, r_obj* sym, r_obj* value) {
-  KEEP(value);
-  Rf_defineVar(sym, value, env);
-  FREE(1);
-}
-
-void r_env_poke_lazy(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env);
-
-static inline
-void r_env_poke_active(r_obj* env, r_obj* sym, r_obj* fn) {
-  KEEP(fn);
-  r_env_unbind(env, sym);
-  R_MakeActiveBinding(sym, fn, env);
-  FREE(1);
-}
 
 bool r_env_inherits(r_obj* env, r_obj* ancestor, r_obj* top);
 

--- a/src/rlang/eval.c
+++ b/src/rlang/eval.c
@@ -3,7 +3,7 @@
 
 r_obj* r_eval_with_x(r_obj* call, r_obj* x, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(1, parent));
-  r_env_poke(env, r_syms.x, x);
+  r_env_bind(env, r_syms.x, x);
 
   r_obj* out = r_eval(call, env);
 
@@ -12,8 +12,8 @@ r_obj* r_eval_with_x(r_obj* call, r_obj* x, r_obj* parent) {
 }
 r_obj* r_eval_with_xy(r_obj* call, r_obj* x, r_obj* y, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(2, parent));
-  r_env_poke(env, r_syms.x, x);
-  r_env_poke(env, r_syms.y, y);
+  r_env_bind(env, r_syms.x, x);
+  r_env_bind(env, r_syms.y, y);
 
   r_obj* out = r_eval(call, env);
 
@@ -22,9 +22,9 @@ r_obj* r_eval_with_xy(r_obj* call, r_obj* x, r_obj* y, r_obj* parent) {
 }
 r_obj* r_eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(3, parent));
-  r_env_poke(env, r_syms.x, x);
-  r_env_poke(env, r_syms.y, y);
-  r_env_poke(env, r_syms.z, z);
+  r_env_bind(env, r_syms.x, x);
+  r_env_bind(env, r_syms.y, y);
+  r_env_bind(env, r_syms.z, z);
 
   r_obj* out = r_eval(call, env);
 
@@ -33,10 +33,10 @@ r_obj* r_eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z, r_obj* parent)
 }
 r_obj* r_eval_with_wxyz(r_obj* call, r_obj* w, r_obj* x, r_obj* y, r_obj* z, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(4, parent));
-  r_env_poke(env, r_syms.w, w);
-  r_env_poke(env, r_syms.x, x);
-  r_env_poke(env, r_syms.y, y);
-  r_env_poke(env, r_syms.z, z);
+  r_env_bind(env, r_syms.w, w);
+  r_env_bind(env, r_syms.x, x);
+  r_env_bind(env, r_syms.y, y);
+  r_env_bind(env, r_syms.z, z);
 
   r_obj* out = r_eval(call, env);
 
@@ -58,42 +58,42 @@ static r_obj* shared_xy_env;
 static r_obj* shared_xyz_env;
 
 r_obj* eval_with_x(r_obj* call, r_obj* x) {
-  r_env_poke(shared_x_env, r_syms.x, x);
+  r_env_bind(shared_x_env, r_syms.x, x);
 
   r_obj* out = KEEP(r_eval(call, shared_x_env));
 
   // Release for gc
-  r_env_poke(shared_x_env, r_syms.x, r_null);
+  r_env_bind(shared_x_env, r_syms.x, r_null);
 
   FREE(1);
   return out;
 }
 
 r_obj* eval_with_xy(r_obj* call, r_obj* x, r_obj* y) {
-  r_env_poke(shared_xy_env, r_syms.x, x);
-  r_env_poke(shared_xy_env, r_syms.y, y);
+  r_env_bind(shared_xy_env, r_syms.x, x);
+  r_env_bind(shared_xy_env, r_syms.y, y);
 
   r_obj* out = KEEP(r_eval(call, shared_xy_env));
 
   // Release for gc
-  r_env_poke(shared_xy_env, r_syms.x, r_null);
-  r_env_poke(shared_xy_env, r_syms.y, r_null);
+  r_env_bind(shared_xy_env, r_syms.x, r_null);
+  r_env_bind(shared_xy_env, r_syms.y, r_null);
 
   FREE(1);
   return out;
 }
 
 r_obj* eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z) {
-  r_env_poke(shared_xyz_env, r_syms.x, x);
-  r_env_poke(shared_xyz_env, r_syms.y, y);
-  r_env_poke(shared_xyz_env, r_syms.z, z);
+  r_env_bind(shared_xyz_env, r_syms.x, x);
+  r_env_bind(shared_xyz_env, r_syms.y, y);
+  r_env_bind(shared_xyz_env, r_syms.z, z);
 
   r_obj* out = KEEP(r_eval(call, shared_xyz_env));
 
   // Release for gc
-  r_env_poke(shared_xyz_env, r_syms.x, r_null);
-  r_env_poke(shared_xyz_env, r_syms.y, r_null);
-  r_env_poke(shared_xyz_env, r_syms.z, r_null);
+  r_env_bind(shared_xyz_env, r_syms.x, r_null);
+  r_env_bind(shared_xyz_env, r_syms.y, r_null);
+  r_env_bind(shared_xyz_env, r_syms.z, r_null);
 
   FREE(1);
   return out;
@@ -135,7 +135,7 @@ r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,
                                int n,
                                r_obj* env) {
   if (fn_sym != r_null) {
-    r_env_poke(env, fn_sym, fn);
+    r_env_bind(env, fn_sym, fn);
     fn = fn_sym;
   }
 
@@ -154,7 +154,7 @@ r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,
     } else {
       // If symbol is supplied, assign the value in the environment and
       // use the symbol instead of the value in the list of arguments
-      r_env_poke(env, tag, car);
+      r_env_bind(env, tag, car);
       r_node_poke_car(node, tag);
     }
 

--- a/src/rlang/formula.c
+++ b/src/rlang/formula.c
@@ -76,11 +76,9 @@ r_obj* new_raw_formula(r_obj* lhs, r_obj* rhs, r_obj* env) {
   }
   f = KEEP(r_new_call(tilde_sym, args));
 
-  r_obj* attrs = KEEP(r_new_node(env, r_null));
-  r_node_poke_tag(attrs, r_sym(".Environment"));
-  r_poke_attrib(f, attrs);
+  r_attrib_poke(f, r_sym(".Environment"), env);
 
-  FREE(3);
+  FREE(2);
   return f;
 }
 r_obj* r_new_formula(r_obj* lhs, r_obj* rhs, r_obj* env) {

--- a/src/rlang/obj.c
+++ b/src/rlang/obj.c
@@ -127,7 +127,7 @@ r_obj* r_as_label(r_obj* x) {
 void r_init_library_obj(r_obj* ns) {
   p_precious_dict = r_new_dict(PRECIOUS_DICT_INIT_SIZE);
   KEEP(p_precious_dict->shelter);
-  r_env_poke(ns,
+  r_env_bind(ns,
              r_sym(".__rlang_lib_precious_dict__."),
              p_precious_dict->shelter);
   FREE(1);
@@ -147,6 +147,3 @@ void r_init_library_obj(r_obj* ns) {
 
 static r_obj* as_label_call = NULL;
 
-void r_mark_object(r_obj* x) {
-  r_attrib_poke_class(x, r_attrib_get(x, r_syms.class_));
-}

--- a/src/rlang/obj.h
+++ b/src/rlang/obj.h
@@ -55,10 +55,6 @@ void _r_preserve_global(r_obj* x) {
    (_r_preserve_global)(_r_placeholder),         \
    (void) NULL)
 
-// Gets class from `x` and resets it. Useful if you used `SET_ATTRIB()` with a
-// cached object structure that includes a `class` attribute.
-void r_mark_object(r_obj* x);
-
 static inline
 bool r_is_object(r_obj* x) {
   return Rf_isObject(x);
@@ -76,10 +72,6 @@ r_obj* r_copy(r_obj* x) {
 static inline
 r_obj* r_clone(r_obj* x) {
   return Rf_shallow_duplicate(x);
-}
-static inline
-r_obj* r_clone_shared(r_obj* x) {
-  return r_is_shared(x) ? r_clone(x) : x;
 }
 
 // These also clone names

--- a/src/rlang/rlang-types.h
+++ b/src/rlang/rlang-types.h
@@ -118,4 +118,75 @@ struct r_lazy {
 #define RLANG_ASSERT(condition) ((void)sizeof(char[1 - 2*!(condition)]))
 
 
+// Polyfills for R API
+
+#if R_VERSION < R_Version(4, 5, 0)
+static inline
+int ANY_ATTRIB(SEXP x) {
+  return ATTRIB(x) != R_NilValue;
+}
+static inline
+void CLEAR_ATTRIB(SEXP x) {
+  SET_ATTRIB(x, R_NilValue);
+  SET_OBJECT(x, 0);
+  UNSET_S4_OBJECT(x);
+}
+#endif
+
+#if R_VERSION < R_Version(4, 6, 0)
+static inline
+bool rlang_promise_is_forced(r_obj* x) {
+  return PRVALUE(x) != R_UnboundValue;
+}
+// Unwrap nested promises to the innermost one.
+// Sets `*forced` to TRUE if the innermost promise is forced.
+// Uses Floyd's cycle detection to guard against promise loops.
+static inline
+r_obj* rlang_promise_unwrap(r_obj* x, bool *forced) {
+  r_obj* slow = x;
+  bool advance_slow = false;
+
+  while (TRUE) {
+    r_obj* expr = PREXPR(x);
+    if (TYPEOF(expr) != PROMSXP) {
+      *forced = rlang_promise_is_forced(x);
+      return x;
+    }
+
+    x = expr;
+    if (x == slow) {
+      Rf_error("Cycle detected in promise chain");
+    }
+
+    if (advance_slow) {
+      slow = PREXPR(slow);
+    }
+    advance_slow = !advance_slow;
+  }
+}
+#endif
+
+#if R_VERSION < R_Version(4, 6, 0)
+static inline
+SEXP R_mapAttrib(SEXP x, SEXP (*FUN)(SEXP, SEXP, void *), void *data) {
+  PROTECT_INDEX api;
+  SEXP a = ATTRIB(x);
+  SEXP val = NULL;
+
+  PROTECT_WITH_INDEX(a, &api);
+  while (a != R_NilValue) {
+    SEXP tag = PROTECT(TAG(a));
+    SEXP attr = PROTECT(CAR(a));
+    val = FUN(tag, attr, data);
+    UNPROTECT(2);
+    if (val != NULL)
+      break;
+    REPROTECT(a = CDR(a), api);
+  }
+  UNPROTECT(1);
+  return val;
+}
+#endif
+
+
 #endif

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -9,6 +9,7 @@
 #include "debug.c"
 #include "dict.c"
 #include "df.c"
+#include "dots-info.c"
 #include "dyn-array.c"
 #include "dyn-list-of.c"
 #include "env.c"

--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -26,7 +26,6 @@
 #include <Rversion.h> // IWYU pragma: export
 #include "rlang-types.h" // IWYU pragma: export
 
-#define R_TREESITTER_BEFORE_NON_API_CLEANUP (R_VERSION < R_Version(4, 5, 0))
 
 r_obj* r_init_library(r_obj* ns);
 
@@ -55,6 +54,7 @@ bool _r_use_local_precious_list;
 #include "df.h"
 #include "dyn-array.h"
 #include "dyn-list-of.h"
+#include "dots-info.h"
 #include "env.h"
 #include "env-binding.h"
 #include "eval.h"

--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -69,7 +69,7 @@ const enum sexp_iterator_state done_state[] = {
 
 
 struct r_sexp_iterator* r_new_sexp_iterator(r_obj* root) {
-  r_obj* shelter = KEEP(r_alloc_list(2));
+  r_obj* shelter = KEEP(r_alloc_list(3));
 
   r_obj* it = r_alloc_raw(sizeof(struct r_sexp_iterator));
   r_list_poke(shelter, 0, it);
@@ -78,9 +78,12 @@ struct r_sexp_iterator* r_new_sexp_iterator(r_obj* root) {
   struct r_dyn_array* p_stack = r_new_dyn_array(sizeof(struct sexp_stack_info), SEXP_STACK_INIT_SIZE);
   r_list_poke(shelter, 1, p_stack->shelter);
 
+  // Slot 2 holds a pairlist chain of collected attribute pairlists
+  // that need protection for the lifetime of the iterator
+
   enum r_type type = r_typeof(root);
   enum sexp_iterator_type it_type = sexp_iterator_type(type, root);
-  bool has_attrib = sexp_node_attrib(type, root) != r_null;
+  bool has_attrib = sexp_has_attrib(type, root);
 
   struct sexp_stack_info root_info = {
     .x = root,
@@ -105,7 +108,7 @@ struct r_sexp_iterator* r_new_sexp_iterator(r_obj* root) {
     .x = r_null,
     .parent = r_null,
   };
-  
+
   FREE(1);
   return p_it;
 }
@@ -180,10 +183,17 @@ bool sexp_next_incoming(struct r_sexp_iterator* p_it,
   child.depth = p_info->depth + 1;
 
   switch (state) {
-  case SEXP_ITERATOR_STATE_attrib:
-    child.x = r_attrib(x);
+  case SEXP_ITERATOR_STATE_attrib: {
+    // Allocates a new pairlist to avoid direct ATTRIB() access.
+    // Could use R_mapAttrib() instead but would require refactoring.
+    r_obj* collected = r_attrib_collect(x);
+    // Protect collected pairlist in the iterator's shelter chain
+    r_obj* chain = r_new_node(collected, r_list_get(p_it->shelter, 2));
+    r_list_poke(p_it->shelter, 2, chain);
+    child.x = collected;
     child.rel = R_SEXP_IT_RELATION_attrib;
     break;
+  }
   case SEXP_ITERATOR_STATE_elt:
     child.x = *p_info->v_arr;
     child.rel = R_SEXP_IT_RELATION_list_elt;
@@ -202,7 +212,7 @@ bool sexp_next_incoming(struct r_sexp_iterator* p_it,
   }
 
   child.type = r_typeof(child.x);
-  bool has_attrib = sexp_node_attrib(child.type, child.x) != r_null;
+  bool has_attrib = sexp_has_attrib(child.type, child.x);
   enum sexp_iterator_type it_type = sexp_iterator_type(child.type, child.x);
 
   if (it_type == SEXP_ITERATOR_TYPE_atomic && !has_attrib) {
@@ -301,12 +311,12 @@ enum sexp_iterator_type sexp_iterator_type(enum r_type type,
   }
 }
 static inline
-r_obj* sexp_node_attrib(enum r_type type, r_obj* x) {
+bool sexp_has_attrib(enum r_type type, r_obj* x) {
   // Strings have private data stored in attributes
   if (type == R_TYPE_string) {
-    return r_null;
+    return false;
   } else {
-    return ATTRIB(x);
+    return r_attrib_has_any(x);
   }
 }
 static inline


### PR DESCRIPTION
Also seeing

```
File ‘treesitter/libs/treesitter.so’:
  Found non-API calls to R: ‘R_MissingArg’, ‘R_NamespaceRegistry’,
    ‘R_UnboundValue’
```

It looks like `R_MissingArg` removal is going to be walked back https://github.com/wch/r-source/commit/226d3f0e513ad83e6fa30fe361fb65442608d992

It looks like `r_syms.unbound = R_UnboundValue;` in rlang is the reason for `R_UnboundValue`, we should fix that. https://github.com/r-lib/rlang/pull/1889

`R_NamespaceRegistry` is new and is unfortunate. Many things use that. We will have to follow up on this with R Core.