### PR TITLE
Mark symbols as hidden

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,7 +1,8 @@
 PKG_CFLAGS = \
         -I./tree-sitter/lib/include \
         -I./tree-sitter/lib/src \
-        -I./rlang
+        -I./rlang \
+        $(C_VISIBILITY)
 
 tree-sitter-files = \
         tree-sitter/lib/src/lib.o

--- a/src/init.c
+++ b/src/init.c
@@ -1,4 +1,5 @@
 #include <R_ext/Rdynload.h>
+#include <R_ext/Visibility.h>
 #include <Rinternals.h>
 #include <stdbool.h>
 #include <stdlib.h>  // for NULL
@@ -229,7 +230,7 @@ static const R_CallMethodDef CallEntries[] = {
     {NULL, NULL, 0}
 };
 
-void R_init_treesitter(DllInfo* dll) {
+attribute_visible void R_init_treesitter(DllInfo* dll) {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
 }


### PR DESCRIPTION
This helps hide symbol collisions in .so in certain environments